### PR TITLE
Dev controller support

### DIFF
--- a/Game/Game.vcxproj
+++ b/Game/Game.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="Source\Textures.cpp" />
     <ClCompile Include="Source\Timer.cpp" />
     <ClCompile Include="Source\Window.cpp" />
+    <ClInclude Include="Source\InputTest.h" />
     <ClInclude Include="Source\Dialog.h" />
     <ClInclude Include="Source\DialogManager.h" />
     <ClInclude Include="Source\DialogTriggerEntity.h" />

--- a/Game/Game.vcxproj.filters
+++ b/Game/Game.vcxproj.filters
@@ -82,6 +82,7 @@
     <ClInclude Include="Source\Dialog.h" />
     <ClInclude Include="Source\DialogManager.h" />
     <ClInclude Include="Source\DialogTriggerEntity.h" />
+    <ClInclude Include="Source\InputTest.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="External">

--- a/Game/Game.vcxproj.user
+++ b/Game/Game.vcxproj.user
@@ -8,4 +8,7 @@
     <LocalDebuggerWorkingDirectory>$(SolutionDir)\Output</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup>
+    <ShowAllFiles>false</ShowAllFiles>
+  </PropertyGroup>
 </Project>

--- a/Game/Source/Input.cpp
+++ b/Game/Source/Input.cpp
@@ -5,10 +5,6 @@
 #include "Defs.h"
 #include "Log.h"
 
-#include <memory>
-#include <stdexcept>
-#include <algorithm>
-
 #define MAX_KEYS 300
 
 #define DEAD_ZONE 0.05f
@@ -183,12 +179,10 @@ bool Input::PreUpdate()
 			break;
 
 			case SDL_CONTROLLERDEVICEREMOVED:
-				if (!controllers.empty()) {
-					for (size_t i = 0; i < controllers.size(); i++)
-					{
-						if (event.cdevice.which == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controllers[i].get()))) {
-							unique_gameController_t sink = std::move(controllers[i]);
-						}
+				for (size_t i = 0; i < controllers.size(); i++)
+				{
+					if (event.cdevice.which == SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controllers[i].get()))) {
+						unique_gameController_t sink = std::move(controllers[i]);
 					}
 				}
 				FindControllers();
@@ -246,9 +240,7 @@ bool Input::GetWindowEvent(EventWindow ev)
 
 const ControlBinding& Input::GetBind(ControlID id)
 {
-	// TODO (Roger) limpieza (borra el chequeo de id)
-	if (id < 0 || id >= bindings.size()) { LOG("Comprueba la configuracion de controles, aqui faltan controles por configurar."); return bindings[0]; }
-	return bindings[id];
+	return bindings.at(id);
 }
 
 void Input::UpdateBindings()
@@ -260,7 +252,7 @@ void Input::UpdateBindings()
 }
 
 void Input::FindControllers() {
-	controllers.clear();
+	controllers.clear(); // NOTE esto puede causar problemas en juegos multijugador, pero como este es de un solo jugador no pasa nada
 	for (int i = 0; i < SDL_NumJoysticks(); i++) {
 		if (SDL_IsGameController(i)) {
 			AddController(i);

--- a/Game/Source/Input.h
+++ b/Game/Source/Input.h
@@ -2,6 +2,7 @@
 #define __INPUT_H__
 
 #include "Module.h"
+#include <vector>
 
 //#define NUM_KEYS 352
 #define NUM_MOUSE_BUTTONS 5
@@ -47,6 +48,9 @@ public:
 	// Called before quitting
 	bool CleanUp();
 
+	// Encuentra todos los mandos compatibles conectado al pc
+	void FindControllers();
+
 	// Check key states (includes mouse and joy buttons)
 	KeyState GetKey(int id) const
 	{
@@ -69,6 +73,7 @@ private:
 	bool windowEvents[WE_COUNT];
 	KeyState*	keyboard;
 	KeyState mouseButtons[NUM_MOUSE_BUTTONS];
+	std::unique_ptr<std::vector<std::unique_ptr<SDL_GameController>>> controllers;
 	int	mouseMotionX;
 	int mouseMotionY;
 	int mouseX;

--- a/Game/Source/Input.h
+++ b/Game/Source/Input.h
@@ -2,6 +2,7 @@
 #define __INPUT_H__
 
 #include "Module.h"
+#include "Point.h"
 #include <vector>
 #include <memory>
 
@@ -23,6 +24,8 @@ enum ControlID {
 	CONFIRM,
 	BACK,
 	PAUSE,
+	MOVE_HORIZONTAL,
+	MOVE_VERTICAL,
 
 	ID_COUNT
 };
@@ -47,7 +50,10 @@ enum KeyState
 struct ControlBinding {
 public:
 
-	ControlBinding(ControlID _id, SDL_Scancode _posKey, SDL_GameControllerButton _posButton, SDL_Scancode _negKey, SDL_GameControllerButton _negButton, SDL_GameControllerAxis _axis, float _maxVal) : id(_id), posKey(_posKey), posButton(_posButton), negKey(_negKey), negButton(_negButton), axis(_axis), maxVal(_maxVal)
+	ControlBinding()
+	{}
+
+	ControlBinding(SDL_Scancode _posKey, SDL_GameControllerButton _posButton, SDL_Scancode _negKey, SDL_GameControllerButton _negButton, SDL_GameControllerAxis _axis, float _maxVal) : posKey(_posKey), posButton(_posButton), negKey(_negKey), negButton(_negButton), axis(_axis), maxVal(_maxVal)
 	{
 		// If any axis-related values is assigned, this binding will update axis data
 		isAxisControl = (axis != SDL_CONTROLLER_AXIS_INVALID
@@ -58,24 +64,35 @@ public:
 
 	void Update(Input* input);
 
-	void AssignPosKey(SDL_Scancode id) { posKey = id; }
-	void AssignPosButton(SDL_GameControllerButton id) { posButton = id; }
-	void AssignNegKey(SDL_Scancode id) { negKey = id; }
-	void AssignNegButton(SDL_GameControllerButton id) { negButton = id; }
-	void AssignAxis(SDL_GameControllerAxis id) { axis = id; }
-	void AssignMaxVal(float val) { maxVal = abs(val); axisVal = MAX(-maxVal, MIN(maxVal, axisVal)); }
+	ControlBinding& SetPKey(SDL_Scancode id) { posKey = id; return *this; }
+	ControlBinding& SetPButton(SDL_GameControllerButton id) { posButton = id; return *this; }
+	ControlBinding& SetNKey(SDL_Scancode id) { negKey = id; return *this; }
+	ControlBinding& SetNButton(SDL_GameControllerButton id) { negButton = id; return *this; }
+	ControlBinding& SetAxisControl(bool val) { isAxisControl = val; axisVal = 0; return *this; }
+	ControlBinding& SetAxis(SDL_GameControllerAxis id) { axis = id; return *this; }
+	ControlBinding& SetMaxVal(float val) { maxVal = abs(val); axisVal = MAX(-maxVal, MIN(maxVal, axisVal)); return *this; }
+
+	// Devuelve el estado del control, combinando teclado y mando
+	KeyState State() const { return state; }
+	// Si isAxisControl == false siempre devolvera 0
+	float Axis() const { return axisVal; }
+
+	void LogData(ControlID id) const;
 
 private:
 
-	bool isAxisControl;
+	bool isAxisControl = false;
 
-	ControlID id = ControlID::NONE;
+	// Teclas y botones
 	SDL_Scancode posKey = SDL_Scancode::SDL_SCANCODE_UNKNOWN;
 	SDL_GameControllerButton posButton = SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_INVALID;
+
+	// Solo para ejes
 	SDL_Scancode negKey = SDL_Scancode::SDL_SCANCODE_UNKNOWN;
 	SDL_GameControllerButton negButton = SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_INVALID;
 	SDL_GameControllerAxis axis = SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_INVALID;
 
+	// Valores
 	KeyState state = KeyState::KEY_IDLE;
 	float axisVal = 0.0f;
 	float maxVal = 1.0f;
@@ -135,6 +152,14 @@ public:
 
 	// Devuelve el estado de un boton, ya sea de teclado o mando
 	const ControlBinding& GetBind(ControlID id);
+
+	// Devuelve el estado del boton cuyo id coincide con el proporcionado
+	KeyState GetButton(ControlID id);
+
+	// Devuelve un eje
+	float GetAxis(ControlID x);
+	// Devuelve dos ejes
+	fPoint GetAxis(ControlID x, ControlID y);
 
 	// Check if a certain window event happened
 	bool GetWindowEvent(EventWindow ev);

--- a/Game/Source/Input.h
+++ b/Game/Source/Input.h
@@ -26,7 +26,7 @@ enum ControlID {
 	PAUSE,
 	MOVE_HORIZONTAL,
 	MOVE_VERTICAL,
-
+	APP_EXIT,
 	ID_COUNT
 };
 
@@ -120,17 +120,6 @@ public:
 	// Called before quitting
 	bool CleanUp();
 
-	// Actualiza los controles asignados
-	void UpdateBindings();
-
-	// Encuentra todos los mandos compatibles conectado al pc
-	void FindControllers();
-
-	// Añade el mando con el id proporcionado a la lista de mandos detectados
-	void AddController(Sint32 id) {
-		controllers.push_back(unique_gameController_t(SDL_GameControllerOpen(id), SDL_GameControllerClose));
-	}
-
 	// Por defecto devuelve el primer mando, o nullptr si no hay mandos conectados
 	SDL_GameController* GetController(uint id = 0) { return (id < controllers.size()) ? controllers[id].get() : nullptr; }
 
@@ -140,18 +129,10 @@ public:
 		return keyboard[id];
 	}
 
-	bool GetKeyRaw(int id) const
-	{
-		return keyboardRaw[id];
-	}
-
 	KeyState GetMouseButtonDown(int id) const
 	{
 		return mouseButtons[id - 1];
 	}
-
-	// Devuelve el estado de un boton, ya sea de teclado o mando
-	const ControlBinding& GetBind(ControlID id);
 
 	// Devuelve el estado del boton cuyo id coincide con el proporcionado
 	KeyState GetButton(ControlID id);
@@ -161,12 +142,31 @@ public:
 	// Devuelve dos ejes
 	fPoint GetAxis(ControlID x, ControlID y);
 
-	// Check if a certain window event happened
-	bool GetWindowEvent(EventWindow ev);
-
 	// Get mouse / axis position
 	void GetMousePosition(int &x, int &y);
 	void GetMouseMotion(int& x, int& y);
+
+	// Check if a certain window event happened
+	bool GetWindowEvent(EventWindow ev);
+
+private:
+
+	bool GetKeyRaw(int id) const
+	{
+		return keyboardRaw[id];
+	}
+
+	// Devuelve el estado de un boton, ya sea de teclado o mando
+	const ControlBinding& GetBind(ControlID id);
+
+	// Actualiza los controles asignados
+	void UpdateBindings();
+
+	// Encuentra todos los mandos compatibles conectado al pc
+	void FindControllers();
+
+	// Añade el mando con el id proporcionado a la lista de mandos detectados
+	void AddController(Sint32 id);
 
 private:
 	bool windowEvents[WE_COUNT];
@@ -180,6 +180,8 @@ private:
 	int mouseY;
 
 	std::vector<ControlBinding> bindings;
+
+	friend ControlBinding;
 
 };
 

--- a/Game/Source/Input.h
+++ b/Game/Source/Input.h
@@ -3,12 +3,29 @@
 
 #include "Module.h"
 #include <vector>
+#include <memory>
+
+#include "SDL/include/SDL.h"
 
 //#define NUM_KEYS 352
 #define NUM_MOUSE_BUTTONS 5
 //#define LAST_KEYS_PRESSED_BUFFER 50
 
 struct SDL_Rect;
+class Input;
+
+// Atajo para smart pointers de tipo SDL_GameController
+using unique_gameController_t = std::unique_ptr<SDL_GameController, decltype(&SDL_GameControllerClose)>;
+
+// Identificadores de controles deben ser añadidos aqui
+enum ControlID {
+	NONE = -1,
+	CONFIRM,
+	BACK,
+	PAUSE,
+
+	ID_COUNT
+};
 
 enum EventWindow
 {
@@ -24,6 +41,44 @@ enum KeyState
 	KEY_DOWN,
 	KEY_REPEAT,
 	KEY_UP
+};
+
+// Contains information about a button and/or axis binding
+struct ControlBinding {
+public:
+
+	ControlBinding(ControlID _id, SDL_Scancode _posKey, SDL_GameControllerButton _posButton, SDL_Scancode _negKey, SDL_GameControllerButton _negButton, SDL_GameControllerAxis _axis, float _maxVal) : id(_id), posKey(_posKey), posButton(_posButton), negKey(_negKey), negButton(_negButton), axis(_axis), maxVal(_maxVal)
+	{
+		// If any axis-related values is assigned, this binding will update axis data
+		isAxisControl = (axis != SDL_CONTROLLER_AXIS_INVALID
+			|| negKey != SDL_SCANCODE_UNKNOWN
+			|| negButton != SDL_CONTROLLER_BUTTON_INVALID);
+			
+	}
+
+	void Update(Input* input);
+
+	void AssignPosKey(SDL_Scancode id) { posKey = id; }
+	void AssignPosButton(SDL_GameControllerButton id) { posButton = id; }
+	void AssignNegKey(SDL_Scancode id) { negKey = id; }
+	void AssignNegButton(SDL_GameControllerButton id) { negButton = id; }
+	void AssignAxis(SDL_GameControllerAxis id) { axis = id; }
+	void AssignMaxVal(float val) { maxVal = abs(val); axisVal = MAX(-maxVal, MIN(maxVal, axisVal)); }
+
+private:
+
+	bool isAxisControl;
+
+	ControlID id = ControlID::NONE;
+	SDL_Scancode posKey = SDL_Scancode::SDL_SCANCODE_UNKNOWN;
+	SDL_GameControllerButton posButton = SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_INVALID;
+	SDL_Scancode negKey = SDL_Scancode::SDL_SCANCODE_UNKNOWN;
+	SDL_GameControllerButton negButton = SDL_GameControllerButton::SDL_CONTROLLER_BUTTON_INVALID;
+	SDL_GameControllerAxis axis = SDL_GameControllerAxis::SDL_CONTROLLER_AXIS_INVALID;
+
+	KeyState state = KeyState::KEY_IDLE;
+	float axisVal = 0.0f;
+	float maxVal = 1.0f;
 };
 
 class Input : public Module
@@ -48,19 +103,38 @@ public:
 	// Called before quitting
 	bool CleanUp();
 
+	// Actualiza los controles asignados
+	void UpdateBindings();
+
 	// Encuentra todos los mandos compatibles conectado al pc
 	void FindControllers();
 
-	// Check key states (includes mouse and joy buttons)
+	// Añade el mando con el id proporcionado a la lista de mandos detectados
+	void AddController(Sint32 id) {
+		controllers.push_back(unique_gameController_t(SDL_GameControllerOpen(id), SDL_GameControllerClose));
+	}
+
+	// Por defecto devuelve el primer mando, o nullptr si no hay mandos conectados
+	SDL_GameController* GetController(uint id = 0) { return (id < controllers.size()) ? controllers[id].get() : nullptr; }
+
+	// Check key states
 	KeyState GetKey(int id) const
 	{
 		return keyboard[id];
+	}
+
+	bool GetKeyRaw(int id) const
+	{
+		return keyboardRaw[id];
 	}
 
 	KeyState GetMouseButtonDown(int id) const
 	{
 		return mouseButtons[id - 1];
 	}
+
+	// Devuelve el estado de un boton, ya sea de teclado o mando
+	const ControlBinding& GetBind(ControlID id);
 
 	// Check if a certain window event happened
 	bool GetWindowEvent(EventWindow ev);
@@ -71,13 +145,17 @@ public:
 
 private:
 	bool windowEvents[WE_COUNT];
+	const Uint8* keyboardRaw;
 	KeyState*	keyboard;
 	KeyState mouseButtons[NUM_MOUSE_BUTTONS];
-	std::unique_ptr<std::vector<std::unique_ptr<SDL_GameController>>> controllers;
+	std::vector<unique_gameController_t> controllers;
 	int	mouseMotionX;
 	int mouseMotionY;
 	int mouseX;
 	int mouseY;
+
+	std::vector<ControlBinding> bindings;
+
 };
 
 #endif // __INPUT_H__

--- a/Game/Source/Player.cpp
+++ b/Game/Source/Player.cpp
@@ -41,6 +41,14 @@ bool Player::Update(float dt)
 {
 	//L03: DONE 4: render the player texture and modify the position of the player using WSAD keys and render the texture
 
+	fPoint joystick = app->input->GetAxis(MOVE_HORIZONTAL, MOVE_VERTICAL);
+	KeyState sprint = app->input->GetButton(BACK);
+	float speed = (sprint == KEY_REPEAT) ? 0.5f : 0.2f;
+
+	position.x += speed * joystick.x * dt;
+	position.y += speed * joystick.y * dt;
+
+	/*
 	if (app->input->GetKey(SDL_SCANCODE_A) == KEY_REPEAT) {
 		position.x += -0.2*dt;
 		if(app->input->GetKey(SDL_SCANCODE_LSHIFT) == KEY_REPEAT)
@@ -65,6 +73,7 @@ bool Player::Update(float dt)
 		if (app->input->GetKey(SDL_SCANCODE_LSHIFT) == KEY_REPEAT)
 			position.y += 0.3 * dt;
 	}
+	*/
 		
 	app->render->DrawTexture(texture,position.x,position.y);
 

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -133,7 +133,8 @@ bool Scene::PostUpdate()
 {
 	bool ret = true;
 
-	if(app->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
+	//if(app->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
+	if (app->input->GetButton(APP_EXIT) == KEY_DOWN)
 		ret = false;
 
 	return ret;


### PR DESCRIPTION
Control unificado entre teclado y mando implementado

- Mientras una de las teclas o botones asignados a un control esté pulsado, no cambiará de estado, impidiendo el cambio rápido entre KEY_DOWN y KEY_REPEAT sin pasar por KEY_UP 
- Compatibilidad con ejes de movimiento: pulsando botones los valores son -1, 0 y 1

Las funciones para acceder a ello son GetButton y GetAxis, proporcionando el ID del control a cuyo valor se quiere acceder.

En esta pull request, el movimiento del jugador ya ha sido reemplazado por el nuevo esquema de controles (teclado/xbox):
- WASD/palanca izquierda: movimiento
- Espacio/A: interactuar
- Shift Izquierdo/B: volver/cancelar/correr
- P/Start: pausa
- Esc/Select: cerrar juego

Dada la naturaleza del juego no he visto necesario implementar múltiples mandos o botones con el mismo origen, pero es posible implementarlo.