### PR TITLE
Bugfix introscreen

### DIFF
--- a/Game/Source/App.cpp
+++ b/Game/Source/App.cpp
@@ -38,24 +38,24 @@ App::App(int argc, char* args[]) : argc(argc), args(args)
 
 	// L3: DONE 1: Add the EntityManager Module to App
 
-	win = new Window();
-	input = new Input();
-	render = new Render();
-	tex = new Textures();
-	audio = new Audio();
+	win = new Window(true);
+	input = new Input(true);
+	render = new Render(true);
+	tex = new Textures(true);
+	audio = new Audio(true);
 	//L07 DONE 2: Add Physics module
-	physics = new Physics();
-	scene = new Scene();
-	titlescreen = new TitleScreen();
-	introScreen = new IntroScreen();
-	teamScreen = new TeamScreen();
-	pause = new PauseMenu();
-	map = new Map();
-	reload = new Reload();
-	entityManager = new EntityManager();
-	guiManager = new GuiManager();
-	dialogManager = new DialogManager();
-	fadeToBlack = new FadeToBlack();
+	physics = new Physics(false);
+	scene = new Scene(false);
+	titlescreen = new TitleScreen(false);
+	introScreen = new IntroScreen(false);
+	teamScreen = new TeamScreen(true);
+	pause = new PauseMenu(false);
+	map = new Map(false);
+	reload = new Reload(true);
+	entityManager = new EntityManager(false);
+	guiManager = new GuiManager(false);
+	dialogManager = new DialogManager(false);
+	fadeToBlack = new FadeToBlack(true);
 
 	// Ordered for awake / Start / Update
 	// Reverse order of CleanUp
@@ -173,7 +173,8 @@ bool App::Start()
 
 	while(item != NULL && ret == true)
 	{
-		ret = item->data->Start();
+		if (item->data->active)
+			ret = item->data->Start();
 		item = item->next;
 	}
 

--- a/Game/Source/Audio.cpp
+++ b/Game/Source/Audio.cpp
@@ -12,7 +12,7 @@
 // NOTE: Library linkage is configured in Linker Options
 //#pragma comment(lib, "../Game/Source/External/SDL_mixer/libx86/SDL2_mixer.lib")
 
-Audio::Audio() : Module()
+Audio::Audio(bool startEnabled) : Module(startEnabled)
 {
 	music = NULL;
 	name.Create("audio");

--- a/Game/Source/Audio.h
+++ b/Game/Source/Audio.h
@@ -12,7 +12,7 @@ class Audio : public Module
 {
 public:
 
-	Audio();
+	Audio(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Audio();

--- a/Game/Source/DialogManager.cpp
+++ b/Game/Source/DialogManager.cpp
@@ -10,7 +10,7 @@
 #include "Log.h"
 #include "SDL_ttf/include/SDL_ttf.h"
 
-DialogManager::DialogManager() : Module()
+DialogManager::DialogManager(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("dialogmanager");
 }

--- a/Game/Source/DialogManager.h
+++ b/Game/Source/DialogManager.h
@@ -12,7 +12,7 @@ class DialogManager : public Module
 {
 public:
 
-	DialogManager();
+	DialogManager(bool startEnabled = true);
 
 	// Destructor
 	virtual ~DialogManager();

--- a/Game/Source/EntityManager.cpp
+++ b/Game/Source/EntityManager.cpp
@@ -11,7 +11,7 @@
 #include "Defs.h"
 #include "Log.h"
 
-EntityManager::EntityManager() : Module()
+EntityManager::EntityManager(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("entitymanager");
 }

--- a/Game/Source/EntityManager.h
+++ b/Game/Source/EntityManager.h
@@ -9,7 +9,7 @@ class EntityManager : public Module
 {
 public:
 
-	EntityManager();
+	EntityManager(bool startEnabled = true);
 
 	// Destructor
 	virtual ~EntityManager();

--- a/Game/Source/GuiManager.cpp
+++ b/Game/Source/GuiManager.cpp
@@ -5,7 +5,7 @@
 #include "GuiControlButton.h"
 #include "Audio.h"
 
-GuiManager::GuiManager() :Module()
+GuiManager::GuiManager(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("guiManager");
 }
@@ -86,18 +86,4 @@ bool GuiManager::CleanUp()
 	return true;
 
 	return false;
-}
-
-
-void GuiManager::DestroyGuiControl(GuiControl* toDestroy) {
-
-	ListItem<GuiControl*>* control;
-	for (control = guiControlsList.start; control != NULL; control = control->next)
-	{
-		if (control->data == toDestroy) {
-			guiControlsList.Del(control);
-			break;
-		}
-	}
-
 }

--- a/Game/Source/GuiManager.h
+++ b/Game/Source/GuiManager.h
@@ -13,7 +13,7 @@ class GuiManager : public Module
 public:
 
 	// Constructor
-	GuiManager();
+	GuiManager(bool startEnabled = true);
 
 	// Destructor
 	virtual ~GuiManager();

--- a/Game/Source/Input.cpp
+++ b/Game/Source/Input.cpp
@@ -7,7 +7,7 @@
 
 #define MAX_KEYS 300
 
-Input::Input() : Module()
+Input::Input(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("input");
 

--- a/Game/Source/Input.h
+++ b/Game/Source/Input.h
@@ -122,7 +122,7 @@ class Input : public Module
 
 public:
 
-	Input();
+	Input(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Input();

--- a/Game/Source/IntroScreen.cpp
+++ b/Game/Source/IntroScreen.cpp
@@ -13,8 +13,9 @@
 #include "TeamScreen.h"
 #include "menu.h"
 
-IntroScreen::IntroScreen(bool startEnabled) : Module()
+IntroScreen::IntroScreen(bool startEnabled) : Module(startEnabled)
 {
+    name.Create("introScreen");
 }
 
 // Destructor
@@ -40,6 +41,7 @@ bool IntroScreen::Start()
     //app->audio->PlayMusic("Assets/Music/titleScreen.ogg", 1.0f);
     SDL_GetWindowSize(app->win->window, &screenWidth, &screenHeight);
 
+    app->audio->PlayFx(introScreenFx);
 
     return true;
 }
@@ -49,16 +51,7 @@ bool IntroScreen::Update(float dt)
 {
     if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
     {
-        app->audio->UnloadFx(introScreenFx);
         app->fadeToBlack->FadeToBlackTransition((Module*)app->introScreen, (Module*)app->titlescreen, 0.0f);
-
-        app->introScreen->Disable();
-        app->introScreen->active = false;
-
-        app->titlescreen->Enable();
-        app->titlescreen->active = true;
-
-        app->audio->PlayFx(app->titlescreen->menuFx);
     }
 
     
@@ -75,6 +68,10 @@ bool IntroScreen::PostUpdate()
 // Called before quitting
 bool IntroScreen::CleanUp()
 {
+    if (introScreenFx != -1) {
+        app->audio->UnloadFx(introScreenFx);
+        introScreenFx = 0;
+    }
     if (introScreenTex != nullptr)
     {
         app->tex->UnLoad(introScreenTex);

--- a/Game/Source/IntroScreen.h
+++ b/Game/Source/IntroScreen.h
@@ -28,13 +28,13 @@ public:
     
 public:
 
-    SDL_Texture* introScreenTex;
-    int introScreenFx;
+    SDL_Texture* introScreenTex = nullptr;
+    int introScreenFx = 0;
 
     Timer timer;
 
-    int screenWidth;
-    int screenHeight;
+    int screenWidth = 0;
+    int screenHeight = 0;
            
     //gui list
     List<GuiControl*> titleButtons;

--- a/Game/Source/Module.h
+++ b/Game/Source/Module.h
@@ -12,20 +12,21 @@ class Module
 {
 public:
 
-	Module(bool startEnabled = false) : active(startEnabled), awoken(false), needsAwaking(false)
+	Module(bool startEnabled = true) : active(startEnabled), awoken(false), needsAwaking(false)
 	{}
 
 	void Init()
 	{
-		active = isEnabled = true;
+		isEnabled = active;
 	}
 
   // Switches isEnabled and calls Start() method
 	bool Enable()
 	{
 		bool ret = false;
-		if (!active) {
+		if (!isEnabled) {
 			active = isEnabled = true;
+			paused = false;
 			ret = Start();
 		}
 		return ret;
@@ -35,8 +36,9 @@ public:
 	bool Disable()
 	{
 		bool ret = false;
-		if (active) {
+		if (isEnabled) {
 			active = isEnabled = false;
+			paused = false;
 			ret = CleanUp();
 		}
 		return ret;
@@ -99,18 +101,29 @@ public:
 
 	inline bool IsEnabled() const { return isEnabled; }
 
+	// Pauses or unpauses the module, and returns the new pause state
+	bool Pause()
+	{
+		active = paused;
+		paused = !active;
+		return paused;
+	}
+
 public:
 
 	SString name;
 	bool active;	
   
-  // variable para FadeToBlack
+	// variable para FadeToBlack. También usado para denotar si el módulo está inicializado o no
 	bool isEnabled = true;
 
-  // variables para modulo Reload
+	// variables para modulo Reload
 	bool awoken;
 	bool needsAwaking; // Algunos módulos necesitan volver a ejecutar Awake() cuando se activan (Ejemplo: EntityManager si se ha creado alguna entidad antes de iniciarlo)
-  
+
+	// Indica si el modulo esta pausado o no
+	bool paused = false;
+
 };
 
 #endif // __MODULE_H__

--- a/Game/Source/PauseMenu.cpp
+++ b/Game/Source/PauseMenu.cpp
@@ -13,8 +13,9 @@
 #include "menu.h"
 
 
-PauseMenu::PauseMenu(bool startEnabled) : Module()
+PauseMenu::PauseMenu(bool startEnabled) : Module(startEnabled)
 {
+    name.Create("pause");
 }
 
 PauseMenu::~PauseMenu()

--- a/Game/Source/Physics.cpp
+++ b/Game/Source/Physics.cpp
@@ -18,11 +18,12 @@
 #pragma comment( lib, "../Game/Source/External/Box2D/libx86/ReleaseLib/Box2D.lib" )
 #endif
 
-Physics::Physics() : Module()
+Physics::Physics(bool startEnabled) : Module(startEnabled)
 {
 	// Initialise all the internal class variables, at least to NULL pointer
 	world = NULL;
 	debug = true;
+	name.Create("physics");
 }
 
 // Destructor

--- a/Game/Source/Physics.h
+++ b/Game/Source/Physics.h
@@ -10,7 +10,7 @@
 #define PIXELS_PER_METER 50.0f // if touched change METER_PER_PIXEL too
 #define METER_PER_PIXEL 0.02f // this is 1 / PIXELS_PER_METER !
 
-#define METERS_TO_PIXELS(m) ((int) floor(PIXELS_PER_METER * m))
+#define METERS_TO_PIXELS(m) ((int) floor(PIXELS_PER_METER * (m)))
 #define PIXEL_TO_METERS(p)  ((float) METER_PER_PIXEL * (p))
 
 #define DEGTORAD 0.0174532925199432957f
@@ -61,7 +61,7 @@ class Physics : public Module, public b2ContactListener // TODO
 public:
 
 	// Constructors & Destructors
-	Physics();
+	Physics(bool startEnabled);
 	~Physics();
 
 	// Main module steps

--- a/Game/Source/Reload.cpp
+++ b/Game/Source/Reload.cpp
@@ -4,7 +4,7 @@
 #include "Box2D/Box2D/Box2D.h"
 #include "Log.h"
 
-Reload::Reload() : Module() {
+Reload::Reload(bool startEnabled) : Module(startEnabled) {
 	name.Create("reload");
 }
 
@@ -27,12 +27,17 @@ bool Reload::Awake(pugi::xml_node config)
 			SString type = moduleNode.attribute("type").as_string();
 			SString moduleName = moduleNode.attribute("name").as_string();
 			Module* mod = app->GetModule(moduleName.GetString());
-			if (type == "r")
-				preset->AddReload(mod);
-			else if (type == "l")
-				preset->AddLoad(mod);
-			else if (type == "u")
-				preset->AddUnload(mod);
+			if (mod) {
+				if (type == "r")
+					preset->AddReload(mod);
+				else if (type == "l")
+					preset->AddLoad(mod);
+				else if (type == "u")
+					preset->AddUnload(mod);
+			}
+			else {
+				LOG("Could not find module \"%s\"", moduleName.GetString());
+			}
 		}
 	}
 

--- a/Game/Source/Reload.h
+++ b/Game/Source/Reload.h
@@ -21,9 +21,9 @@ struct ReloadPreset {
 	{}
 
 	bool AddReload(Module* m) {
-		AddUnload(m);
-		AddLoad(m);
-		return true;
+		
+		
+		return AddUnload(m) && AddLoad(m);
 	}
 	bool AddUnload(Module* m) {
 		bool ret = true;
@@ -51,7 +51,7 @@ enum class ReloadStep {
 class Reload : public Module
 {
 public:
-    Reload();
+    Reload(bool startEnabled = true);
 
     // Destructor
     virtual ~Reload();

--- a/Game/Source/Render.cpp
+++ b/Game/Source/Render.cpp
@@ -7,7 +7,7 @@
 
 #define VSYNC true
 
-Render::Render() : Module()
+Render::Render(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("renderer");
 	background.r = 0;

--- a/Game/Source/Render.h
+++ b/Game/Source/Render.h
@@ -12,7 +12,7 @@ class Render : public Module
 {
 public:
 
-	Render();
+	Render(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Render();

--- a/Game/Source/Scene.cpp
+++ b/Game/Source/Scene.cpp
@@ -22,7 +22,7 @@
 #include "GuiManager.h"
 #include "GuiControlButton.h"
 
-Scene::Scene() : Module()
+Scene::Scene(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("scene");
 }
@@ -42,10 +42,6 @@ bool Scene::Awake(pugi::xml_node config)
 	player = (Player*) app->entityManager->CreateEntity(EntityType::PLAYER);
 	//Assigns the XML node to a member in player
 	player->config = config.child("player");
-
-	//Get the map name from the config file and assigns the value in the module
-	app->map->name = config.child("map").attribute("name").as_string();
-	app->map->path = config.child("map").attribute("path").as_string();
 
 	// iterate all items in the scene
 	// Check https://pugixml.org/docs/quickstart.html#access
@@ -164,12 +160,12 @@ bool Scene::PostUpdate()
 	if (app->input->GetKey(SDL_SCANCODE_ESCAPE) == KEY_DOWN)
 	{
 		//Destroy all the buttons in the title screen
-		ListItem<GuiControl*>* controlListMenu = nullptr;
-		for (controlListMenu = app->titlescreen->titleButtons.start; controlListMenu != NULL; controlListMenu = controlListMenu->next)
-		{
-			app->guiManager->DestroyGuiControl(controlListMenu->data);
-		}
-		app->titlescreen->titleButtons.Clear();
+		//ListItem<GuiControl*>* controlListMenu = nullptr;
+		//for (controlListMenu = app->titlescreen->titleButtons.start; controlListMenu != NULL; controlListMenu = controlListMenu->next)
+		//{
+		//	app->guiManager->DestroyGuiControl(controlListMenu->data);
+		//}
+		//app->titlescreen->titleButtons.Clear();
 
 		app->guiManager->active = true;
 		app->guiManager->Enable();

--- a/Game/Source/Scene.h
+++ b/Game/Source/Scene.h
@@ -12,7 +12,7 @@ class Scene : public Module
 {
 public:
 
-	Scene();
+	Scene(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Scene();

--- a/Game/Source/TeamScreen.cpp
+++ b/Game/Source/TeamScreen.cpp
@@ -14,8 +14,9 @@
 #include "Scene.h"
 
 
-TeamScreen::TeamScreen(bool startEnabled) : Module()
+TeamScreen::TeamScreen(bool startEnabled) : Module(startEnabled)
 {
+    name.Create("teamScreen");
 }
 
 // Destructor
@@ -26,16 +27,6 @@ TeamScreen::~TeamScreen()
 bool TeamScreen::Start()
 {
     logoScreenTex = app->tex->Load("Assets/Screens/TeamLogo.png");
-
-    app->teamScreen->Enable();
-    app->teamScreen->active = true;
-
-    app->scene->active = false;
-    app->scene->Disable();
-    app->titlescreen->active = false;
-    app->titlescreen->Disable();
-    app->introScreen->active = false;
-    app->introScreen->Disable();
 
     app->render->camera.x = 0;
     app->render->camera.y = 0;
@@ -57,16 +48,7 @@ bool TeamScreen::Update(float dt)
 {
     if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
     {
-        app->audio->UnloadFx(logoFX);
         app->fadeToBlack->FadeToBlackTransition((Module*)app->teamScreen, (Module*)app->introScreen, 0.0f);
-       
-		app->teamScreen->Disable();
-        app->teamScreen->active = false;
-
-        app->introScreen->Enable();
-        app->introScreen->active = true;
-
-        app->audio->PlayFx(app->introScreen->introScreenFx);
 
 	}
 
@@ -85,6 +67,11 @@ bool TeamScreen::PostUpdate()
 // Called before quitting
 bool TeamScreen::CleanUp()
 {
+    if (logoFX > 0) {
+        app->audio->UnloadFx(logoFX);
+        logoFX = 0;
+    }
+
     if (logoScreenTex != nullptr)
     {
         app->tex->UnLoad(logoScreenTex);

--- a/Game/Source/Textures.cpp
+++ b/Game/Source/Textures.cpp
@@ -8,7 +8,7 @@
 #include "SDL_image/include/SDL_image.h"
 //#pragma comment(lib, "../Game/Source/External/SDL_image/libx86/SDL2_image.lib")
 
-Textures::Textures() : Module()
+Textures::Textures(bool startEnabled) : Module(startEnabled)
 {
 	name.Create("textures");
 }

--- a/Game/Source/Textures.h
+++ b/Game/Source/Textures.h
@@ -12,7 +12,7 @@ class Textures : public Module
 {
 public:
 
-	Textures();
+	Textures(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Textures();

--- a/Game/Source/Window.cpp
+++ b/Game/Source/Window.cpp
@@ -7,7 +7,7 @@
 #include "SDL/include/SDL.h"
 
 
-Window::Window() : Module()
+Window::Window(bool startEnabled) : Module(startEnabled)
 {
 	window = NULL;
 	screenSurface = NULL;

--- a/Game/Source/Window.h
+++ b/Game/Source/Window.h
@@ -14,7 +14,7 @@ class Window : public Module
 {
 public:
 
-	Window();
+	Window(bool startEnabled = true);
 
 	// Destructor
 	virtual ~Window();

--- a/Game/Source/menu.cpp
+++ b/Game/Source/menu.cpp
@@ -15,7 +15,7 @@
 #include "IntroScreen.h"
 #include "TeamScreen.h"
 
-TitleScreen::TitleScreen(bool startEnabled) : Module()
+TitleScreen::TitleScreen(bool startEnabled) : Module(startEnabled)
 {
     name.Create("titlescreen");
 }
@@ -27,8 +27,6 @@ TitleScreen::~TitleScreen()
 // Called before render is available
 bool TitleScreen::Start()
 {
-    app->scene->active = false;
-    app->scene->Disable();
     
     menuFx = app->audio->LoadFx("Assets/Audio/Fx/menuFX.wav");
     
@@ -44,6 +42,8 @@ bool TitleScreen::Start()
 
     CreateTitleButtons();
 
+    app->audio->PlayFx(menuFx);
+
     return true;
 }
 
@@ -54,18 +54,7 @@ bool TitleScreen::Update(float dt)
     {
         if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
         {
-            app->audio->UnloadFx(menuFx);
-            app->fadeToBlack->FadeToBlackTransition((Module*)app->titlescreen, (Module*)app->scene, 0.0f);
-
-            app->titlescreen->Disable();
-            app->titlescreen->active = false;
-
-            app->scene->Enable();
-            app->scene->active = true;
-
-            app->guiManager->active = false;
-            app->guiManager->Disable();
-
+            
             app->audio->PlayFx(app->scene->cityFx);
         }
     }
@@ -74,17 +63,7 @@ bool TitleScreen::Update(float dt)
     {
         if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
         {
-            app->audio->UnloadFx(menuFx);
             app->fadeToBlack->FadeToBlackTransition((Module*)app->titlescreen, (Module*)app->scene, 0.0f);
-
-            app->titlescreen->Disable();
-            app->titlescreen->active = false;
-
-            app->scene->Enable();
-            app->scene->active = true;
-
-            app->guiManager->active = false;
-            app->guiManager->Disable();
 
             app->audio->PlayFx(app->scene->cityFx);
         }
@@ -94,17 +73,7 @@ bool TitleScreen::Update(float dt)
     {
         if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
         {
-            app->audio->UnloadFx(menuFx);
             app->fadeToBlack->FadeToBlackTransition((Module*)app->titlescreen, (Module*)app->scene, 0.0f);
-
-            app->titlescreen->Disable();
-            app->titlescreen->active = false;
-
-            app->scene->Enable();
-            app->scene->active = true;
-
-            app->guiManager->active = false;
-            app->guiManager->Disable();
 
             app->audio->PlayFx(app->scene->cityFx);
         }
@@ -114,11 +83,11 @@ bool TitleScreen::Update(float dt)
     {
         if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
         {
-            SDL_Quit();
+            app->Quit();
         }
     }
 
-    if (app->input->GetAxis(ControlID::MOVE_VERTICAL) <= -0.4f) //arriba
+    if (app->input->GetButton(ControlID::UP) == KEY_REPEAT) //arriba
     {
         if (timer.ReadMSec() >= 200)
         {
@@ -127,7 +96,7 @@ bool TitleScreen::Update(float dt)
             timer.Start();
         }
     }
-    if (app->input->GetAxis(ControlID::MOVE_VERTICAL) >= 0.4f) //abajo
+    if (app->input->GetAxis(ControlID::DOWN) == KEY_REPEAT) //abajo
     {
         if (timer.ReadMSec() >= 200)
         {
@@ -136,19 +105,11 @@ bool TitleScreen::Update(float dt)
             timer.Start();
         }
     }
-    if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN)
+    if (app->input->GetButton(ControlID::CONFIRM) == KEY_DOWN && titleButtons.Count()>=menuIndex)
     {
         titleButtons[menuIndex - 1]->state = GuiControlState::PRESSED;
         titleButtons[menuIndex - 1]->NotifyObserver();
     }
-
-    //if (App->input->GetKey(SDL_SCANCODE_RETURN) == KEY_DOWN)
-    //{
-    //    if (menuIndex == 1) App->network->optionsIndex = 1;
-    //    //else if (menuIndex == 2) App->network->optionsIndex = 2;
-    //    //else if (menuIndex == 3) App->network->optionsIndex = 3;
-    //    else if (menuIndex == 4) return UPDATE_STOP;
-    //}
 
     ListItem<GuiControlButton*>* controlListItem = nullptr;
     for (controlListItem = titleButtons.start; controlListItem != NULL; controlListItem = controlListItem->next)
@@ -162,11 +123,12 @@ bool TitleScreen::Update(float dt)
     {
         titleButtons[menuIndex - 1]->state = GuiControlState::SELECTED;
     }
-  
+
+  /*
     if (menuIndex == 1) app->render->DrawTexture(menu1, 0, 0, NULL);
     else if (menuIndex == 2) app->render->DrawTexture(menu2, 0, 0, NULL);
     else if (menuIndex == 3) app->render->DrawTexture(menu3, 0, 0, NULL);
-    else if (menuIndex == 4) app->render->DrawTexture(menu4, 0, 0, NULL);
+    else if (menuIndex == 4) app->render->DrawTexture(menu4, 0, 0, NULL);*/
 
     return true;
 }
@@ -208,7 +170,12 @@ bool TitleScreen::CleanUp()
         menu4 = nullptr;
     }
 
-    //TODO: cambiar cuando se cambie la funcionalidad de los botones
+    if (menuFx > 0) {
+        app->audio->UnloadFx(menuFx);
+        menuFx = 0;
+    }
+
+
     ListItem<GuiControlButton*>* controlListItem = nullptr;
     for (controlListItem = titleButtons.start; controlListItem != NULL; controlListItem = controlListItem->next)
     {
@@ -258,12 +225,12 @@ void NewGame(GuiControl* ctrl)
 
 void Continue(GuiControl* ctrl)
 {
-    app->map->ChangeMap(1); // TODO el id de mapa debe depender de lo que haya en la partida guardada en el caso de continuar partida
+    app->map->ChangeMap(1); // TODO el id de mapa debe depender de lo que haya en la partida guardada en el caso de continuar partida. Para ello esta llamada debe cambiarse por una al gestor de partidas (cuando exista)
 }
 
 void Options(GuiControl* ctrl)
 {
-
+    app->audio->PlayFx(app->scene->cityFx);
 }
 
 void Exit(GuiControl* ctrl)

--- a/Output/config.xml
+++ b/Output/config.xml
@@ -130,23 +130,38 @@
 
 	<reload>
 		<presets>
+			<!--Si el modulo ya esta activo, no se intenta reactivar a menos de que se marque como reload (y aun asi primero lo desactiva)-->
+			<!--l = activar (Load), u = desactivar (Unload), r = ambos (Reload)-->
+			<!--El orden de los módulos es importante, igual que para el bucle principal del juego-->
+			<!--Unload va de final a inicio, Load va de inicio a final-->
 			<preset name="loadMap" fadeOut="1" fadeIn="1">
 				<!--Hay que tener en cuenta todo lo que se cargue desde la informacion de mapa y reiniciarlo también-->
-				<!--<module type="r" name="textures"/>-->
+				<module type="r" name="textures"/>
 				<!--<module type="r" name="audio"/>-->
-				<!--<module type="r" name="physics"/>-->
-				<!--<module type="r" name="scene"/>-->
-				<module type="u" name="titlescreen"/> <!--Cuando cargas mapa no va a estar el menú principal cargado-->
+				<module type="r" name="physics"/>
+				<module type="r" name="scene"/>
 				<module type="r" name="map"/>
-				<!--<module type="r" name="entitymanager"/>-->
+				<module type="r" name="entitymanager"/>
+				<module type="r" name="dialogmanager"/>
+				<module type="u" name="titlescreen"/> <!--Cuando cargas mapa no va a estar el menú principal cargado-->
+				<module type="l" name="pause"/>
 			</preset>
-			<!--Los dos presets de mainMenuUnload son para su uso en menús fuera de partida-->
-			<preset name="mainMenuUnload" fadeOut="0" fadeIn="0">
-				<module type="u" name="titlescreen"/>
+			<preset name="teamLogoToIntro" fadeOut="0.5" fadeIn="0.5">
+				<module type="u" name="teamScreen"/>
+				<module type="l" name="introScreen"/>
 			</preset>
-			<preset name="mainMenuLoad" fadeOut="0" fadeIn="0">
+			<preset name="introToTitle" fadeOut="0.5" fadeIn="0.5">
+				<module type="u" name="introScreen"/>
+				<module type="l" name="guiManager"/>
 				<module type="l" name="titlescreen"/>
+				<module/>
 			</preset>
+			<preset name="titleToGame" fadeOut="1" fadeIn="1">
+				<module type="u" name="titlescreen"/>
+				<module type="l" name="map"/>
+				<module/>
+			</preset>
+			
 		</presets>
 	</reload>
 


### PR DESCRIPTION
Hay módulos que estaban haciendo tareas de otros módulos (abriendo el menú de pausa desde Scene, reproduciendo efectos de sonido guardados en otro módulo, etc.)

La música está puesta como si fuera un efecto de sonido. Hay una implementación para ponerla de fondo en bucle que funciona lo bastante bien (no solucionado en este parche)

Algunos módulos no tienen la variable "name" asignada, lo cual puede dar problemas a la hora de cargar la configuración de módulo, la cual no debe estar "hardcodeada". Todos los módulos (o al menos la mayoría) tienen ahora un nombre asignado.

Creadas las transiciones usando el módulo Reload (por ahora aún se usa FadeToBlack para todo antes de cargar el mapa, es funcionalmente idéntico excepto para esa parte)

El módulo Scene tenía aún el código para cargar el mapa manualmente, así que lo he quitado (todo lo del módulo mapa va por config). Falta quitar la instanciación de entidades, pero aún no están los datos necesarios en el archivo de mapa.